### PR TITLE
`gpt-image-1` Image Model. `gpt-4.1*` Chat Models. Model limiting.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,4 @@
 FROM python:3-alpine
-RUN apk add --no-cache ffmpeg
 RUN mkdir -p /usr/app/
 WORKDIR /usr/app/
 COPY requirements.txt .

--- a/ai_helpers.py
+++ b/ai_helpers.py
@@ -139,19 +139,23 @@ def check_model_limit(context: CommandContext, usage_tracker: dict) -> bool:
     usage_limits = {model: int(count) for model, count in config["OPENAI_MODEL_LIMITS"].items()}
     limit = usage_limits.get(model)
 
+    # do not limit models that don't have a specified limit in the config
     if not limit:
         return True
 
     today = datetime.now().strftime("%Y-%m-%d")
 
+    # create a blank dictionary for a guild if it isn't present in the map already
     if context.guild_id not in usage_tracker:
         usage_tracker[context.guild_id] = {}
 
+    # initialize a model usage dict for the limited-use model
     if model not in usage_tracker[context.guild_id]:
         usage_tracker[context.guild_id][model] = {"count": 0, "last_reset": today, "limit": limit}
 
     record = usage_tracker[context.guild_id][model]
 
+    # reset the usage on a new day
     if record["last_reset"] != today:
         record["count"] = 0
         record["last_reset"] = today
@@ -160,6 +164,7 @@ def check_model_limit(context: CommandContext, usage_tracker: dict) -> bool:
     if record["count"] >= limit:
         return False  # Limit reached
 
+    # increment the count
     record["count"] += 1
 
     return True

--- a/ai_helpers.py
+++ b/ai_helpers.py
@@ -128,3 +128,38 @@ def content_path(context: CommandContext, file_name: str) -> Path:
     dir_path = Path(f"generated_content/guild_{context.guild_id}/{ts}/{context.command_name}")
     dir_path.mkdir(parents=True, exist_ok=True)
     return dir_path / file_name
+
+
+def check_model_limit(context: CommandContext, usage_tracker: dict) -> bool:
+    """
+    A function to check if a model's usage has reached a limit specified in the config
+    """
+    config = get_config()
+    model: str = context.params.get("model")
+    usage_limits = {model: int(count) for model, count in config["OPENAI_MODEL_LIMITS"].items()}
+    limit = usage_limits.get(model)
+
+    if not limit:
+        return True
+
+    today = datetime.now().strftime("%Y-%m-%d")
+
+    if context.guild_id not in usage_tracker:
+        usage_tracker[context.guild_id] = {}
+
+    if model not in usage_tracker[context.guild_id]:
+        usage_tracker[context.guild_id][model] = {"count": 0, "last_reset": today, "limit": limit}
+
+    record = usage_tracker[context.guild_id][model]
+
+    if record["last_reset"] != today:
+        record["count"] = 0
+        record["last_reset"] = today
+        record["limit"] = limit
+
+    if record["count"] >= limit:
+        return False  # Limit reached
+
+    record["count"] += 1
+
+    return True

--- a/app.py
+++ b/app.py
@@ -311,7 +311,9 @@ async def chat(
     interaction: Interaction,
     input_text: str,
     keep_chatting: Literal["Yes", "No"] = "No",
-    model: Literal["gpt-3.5-turbo", "gpt-4o-mini", "gpt-4.5-preview", "gpt-4o"] = "gpt-4o-mini",
+    model: Literal[
+        "gpt-3.5-turbo", "gpt-4o-mini", "gpt-4.5-preview", "gpt-4o", "gpt-4.1", "gpt-4.1-mini"
+    ] = "gpt-4o-mini",
     custom_instructions: Optional[str] = None,
 ) -> None:
 

--- a/config.ini
+++ b/config.ini
@@ -9,6 +9,9 @@ vision_model = gpt-4o
 voice = onyx
 max_output_tokens = 500
 
+[OPENAI_MODEL_LIMITS]
+gpt-image-1 = 5
+
 [OPENAI_INSTRUCTIONS]
 rather_normal = "You are an assistant that provides hypothetical questions in the form of 'would you rather' that would spur interesting conversation in an online chat room."
 rather_adult = "You are an assistant that provides sexually-suggestive, adult-themed hypothetical questions in the format of 'would you rather' that would spur interesting conversation in an online chat room."

--- a/db_utils.py
+++ b/db_utils.py
@@ -60,16 +60,20 @@ class Chat(SQLModel, table=True):
     updated: datetime
 
 
-async def create_command_context(interaction: Interaction, **kwargs) -> CommandContext:
+async def create_command_context(interaction: Interaction, params: Optional[Dict[str, Any]] = None) -> CommandContext:
     """
     Helper function to create CommandContext entry.
     """
+
+    if not params:
+        params = {}
+
     context = CommandContext(
         guild_id=interaction.guild_id,
         user_id=interaction.user.id,
         user=interaction.user.name,
         command_name=interaction.command.name,
-        **kwargs,
+        params=params,
     )
 
     return context

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-openai==1.76.0
+openai==1.76.2
 discord.py[voice]==2.5.2
 sqlmodel==0.0.24
 cryptography==44.0.2

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,4 @@
-ffmpeg-python==0.2.0
-openai==1.68.2
+openai==1.76.0
 discord.py[voice]==2.5.2
 sqlmodel==0.0.24
 cryptography==44.0.2


### PR DESCRIPTION
- `gpt-image-1` now available with `/image`
  - More options in `/image` to handle `gpt-image-1`'s uniqueness
- `gpt-4.1` suite of models now available with `/chat`
- Crude function and map to handle specific model limits

Closes #37
Closes #36